### PR TITLE
require CPU_ARCH build arg and use it to add 'cpu_arch' label and $CPU_ARCH env var to GCC 9.3.0 container image

### DIFF
--- a/containers/Dockerfile.centos7-GCC-9.3.0
+++ b/containers/Dockerfile.centos7-GCC-9.3.0
@@ -1,4 +1,11 @@
 FROM easybuilders/base:centos7-eb4.2.1
+# CPU_ARCH is expected to be defined in the "docker build" command,
+# for example: docker build --build-arg CPU_ARCH=haswell
+ARG CPU_ARCH
+LABEL cpu_arch=${CPU_ARCH}
+# verify provided CPU_ARCH value, should match with what archspec produces
+RUN test "${CPU_ARCH}" == "$(python3 -c 'import archspec.cpu; print(archspec.cpu.host())')"
+# for example: docker build --build-arg CPU_ARCH=haswell
 # create /scratch & /easybuild directories
 USER root
 RUN mkdir /scratch && chown easybuild:easybuild /scratch

--- a/containers/Dockerfile.centos7-GCC-9.3.0
+++ b/containers/Dockerfile.centos7-GCC-9.3.0
@@ -4,11 +4,12 @@ FROM easybuilders/base:centos7-eb4.2.1
 ARG CPU_ARCH
 # make sure CPU_ARCH is defined
 RUN test -n "${CPU_ARCH}" || (echo "\$CPU_ARCH undefined, use 'docker build --build-arg CPU_ARCH=...'" && exit 1)
-LABEL cpu_arch=${CPU_ARCH}
-ENV CPU_ARCH=${CPU_ARCH}
 # verify provided CPU_ARCH value, should match with what archspec produces
 RUN export HOST_CPU_ARCH=$(python3 -c 'import archspec.cpu; print(archspec.cpu.host())') && \
   (test "${CPU_ARCH}" == "$HOST_CPU_ARCH" || (echo "Host CPU arch '${HOST_CPU_ARCH}' doesn't match specified CPU arch '${CPU_ARCH}'!" && exit 1))
+# use $CPU_ARCH to define label and set it as environment variable (to use in subsequent builds
+LABEL cpu_arch=${CPU_ARCH}
+ENV CPU_ARCH=${CPU_ARCH}
 # for example: docker build --build-arg CPU_ARCH=haswell
 # create /scratch & /easybuild directories
 USER root

--- a/containers/Dockerfile.centos7-GCC-9.3.0
+++ b/containers/Dockerfile.centos7-GCC-9.3.0
@@ -5,6 +5,7 @@ ARG CPU_ARCH
 # make sure CPU_ARCH is defined
 RUN test -n "${CPU_ARCH}" || (echo "\$CPU_ARCH undefined, use 'docker build --build-arg CPU_ARCH=...'" && exit 1)
 LABEL cpu_arch=${CPU_ARCH}
+ENV CPU_ARCH=${CPU_ARCH}
 # verify provided CPU_ARCH value, should match with what archspec produces
 RUN export HOST_CPU_ARCH=$(python3 -c 'import archspec.cpu; print(archspec.cpu.host())') && \
   (test "${CPU_ARCH}" == "$HOST_CPU_ARCH" || (echo "Host CPU arch '${HOST_CPU_ARCH}' doesn't match specified CPU arch '${CPU_ARCH}'!" && exit 1))

--- a/containers/Dockerfile.centos7-GCC-9.3.0
+++ b/containers/Dockerfile.centos7-GCC-9.3.0
@@ -2,9 +2,12 @@ FROM easybuilders/base:centos7-eb4.2.1
 # CPU_ARCH is expected to be defined in the "docker build" command,
 # for example: docker build --build-arg CPU_ARCH=haswell
 ARG CPU_ARCH
+# make sure CPU_ARCH is defined
+RUN test -n "${CPU_ARCH}" || (echo "\$CPU_ARCH undefined, use 'docker build --build-arg CPU_ARCH=...'" && exit 1)
 LABEL cpu_arch=${CPU_ARCH}
 # verify provided CPU_ARCH value, should match with what archspec produces
-RUN test "${CPU_ARCH}" == "$(python3 -c 'import archspec.cpu; print(archspec.cpu.host())')"
+RUN export HOST_CPU_ARCH=$(python3 -c 'import archspec.cpu; print(archspec.cpu.host())') && \
+  (test "${CPU_ARCH}" == "$HOST_CPU_ARCH" || (echo "Host CPU arch '${HOST_CPU_ARCH}' doesn't match specified CPU arch '${CPU_ARCH}'!" && exit 1))
 # for example: docker build --build-arg CPU_ARCH=haswell
 # create /scratch & /easybuild directories
 USER root


### PR DESCRIPTION
@ChristianKniep This makes sense to me, but they in which `CPU_ARCH` is enforced could maybe be better?